### PR TITLE
Dont force http or the https version wont work

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,8 +7,8 @@
 <!--  <link href="//netdna.bootstrapcdn.com/font-awesome/4.0.3/css/font-awesome.css" rel="stylesheet">-->
 <!--  <link href='https://www.mapbox.com/base/latest/base.css' rel='stylesheet' />-->
   <link href='//netdna.bootstrapcdn.com/bootstrap/3.1.1/css/bootstrap.min.css' rel='stylesheet' />
-  <link rel="stylesheet" href="http://cdn.leafletjs.com/leaflet-0.7.1/leaflet.css" />
-  <script src="http://cdn.leafletjs.com/leaflet-0.7.2/leaflet.js"></script>
+  <link rel="stylesheet" href="//cdn.leafletjs.com/leaflet-0.7.1/leaflet.css" />
+  <script src="//cdn.leafletjs.com/leaflet-0.7.2/leaflet.js"></script>
   <script src='Leaflet.LocationShare.js'></script>
   <style>
   .mapContainer {


### PR DESCRIPTION
When you go to: https://cliffcloud.github.io/Leaflet.LocationShare/ the example doesnt work with an error in console

`Mixed Content: The page at 'https://cliffcloud.github.io/Leaflet.LocationShare/' was loaded over HTTPS, but requested an insecure stylesheet 'http://cdn.leafletjs.com/leaflet-0.7.1/leaflet.css'. This request has been blocked; the content must be served over HTTPS.`
