### PR TITLE
Accessible button

### DIFF
--- a/Leaflet.LocationShare.js
+++ b/Leaflet.LocationShare.js
@@ -41,7 +41,9 @@ L.Control.ShareLocation = L.Control.extend({
         this.link = L.DomUtil.create('a', 'leaflet-bar-part', container);
         this.link.title = this.options.title;
         var userIcon = L.DomUtil.create('img' , 'img-responsive' , this.link);
-        userIcon.src = 'https://raw.githubusercontent.com/CliffCloud/Leaflet.LocationShare/master/dist/images/IconLocShare.png'
+        userIcon.src = 'https://raw.githubusercontent.com/CliffCloud/Leaflet.LocationShare/master/dist/images/IconLocShare.png';
+        userIcon.alt = '';
+        userIcon.setAttribute('role', 'presentation');
         this.link.href = '#';
 
         L.DomEvent.on(this.link, 'click', this._click, this);

--- a/Leaflet.LocationShare.js
+++ b/Leaflet.LocationShare.js
@@ -45,6 +45,7 @@ L.Control.ShareLocation = L.Control.extend({
         userIcon.alt = '';
         userIcon.setAttribute('role', 'presentation');
         this.link.href = '#';
+        this.link.setAttribute('role', 'button');
 
         L.DomEvent.on(this.link, 'click', this._click, this);
 


### PR DESCRIPTION
- [x] https://github.com/CliffCloud/Leaflet.LocationShare/commit/87cb18a63b1e4e3e14f89afbf60fa74bddd9a064 hides the image element from screen readers.<br>
  See related resources:
  - https://github.com/Leaflet/Leaflet/blob/37d2fd15ad6518c254fae3e033177e96c48b5012/src/layer/tile/TileLayer.js#L146-L156
  - https://www.w3.org/WAI/tutorials/images/decorative/<br><br>
- [x] https://github.com/CliffCloud/Leaflet.LocationShare/commit/1395d2aa78f79adf2e7c76d834114ba3dc5f42e3 adds `role=button` so that screen readers announce "button" as opposed to "link" when focused.<br>
  See related resources:
  - https://github.com/Leaflet/Leaflet/blob/e76f97cba319d97482e395279000ac95de5a8d99/src/control/Control.Zoom.js#L91
  - https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/button_role